### PR TITLE
[feat] Adds bitmap rendering mode for patchables

### DIFF
--- a/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -47,9 +46,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
+import de.berlindroid.zepatch.ui.PatchableBoundingBox
+import de.berlindroid.zepatch.ui.PatchableToBitmap
 import de.berlindroid.zepatch.ui.theme.ZePatchTheme
 import kotlinx.coroutines.launch
 
@@ -159,20 +159,6 @@ private fun PatchableList(
     }
 }
 
-@Composable
-private fun PatchableBoundingBox(
-    modifier: Modifier = Modifier,
-    patchable: @Composable () -> Unit
-) {
-    Box(
-        modifier = modifier.border(
-            width = 1.dp,
-            color = Color.Black,
-        ),
-    ) {
-        patchable()
-    }
-}
 
 @ExperimentalMaterial3Api
 @Composable
@@ -229,12 +215,12 @@ private fun PatchableDetail(
             }
             when (currentMode) {
                 PatchablePreviewMode.COMPOSABLE -> PatchableBoundingBox(patchable = patchable)
-                PatchablePreviewMode.TBD -> Text("Not implemented")
+                PatchablePreviewMode.BITMAP -> PatchableToBitmap(patchable = patchable)
             }
         }
     }
 }
 
 private enum class PatchablePreviewMode {
-    COMPOSABLE, TBD
+    COMPOSABLE, BITMAP
 }

--- a/app/src/main/java/de/berlindroid/zepatch/patchable/Demo.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/patchable/Demo.kt
@@ -1,12 +1,10 @@
 package de.berlindroid.zepatch.patchable
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import de.berlindroid.zepatch.ui.SafeArea
 
 @Composable
 fun Demo(
@@ -17,21 +15,8 @@ fun Demo(
     }
 }
 
-// TODO: share this?
-@Composable
-fun SafeArea(
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    Box(
-        modifier = modifier.padding(32.dp),
-    ) {
-        content()
-    }
-}
-
 @Preview
 @Composable
 fun PreviewDemo() {
-
+    Demo()
 }

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
@@ -1,0 +1,43 @@
+package de.berlindroid.zepatch.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import de.berlindroid.zepatch.utils.CaptureToBitmap
+
+/**
+ * Renders the provided [patchable] into a Bitmap-like [ImageBitmap] and displays it via [Image].
+ * Uses a composable utility that captures the composed content from a graphics layer.
+ */
+@Composable
+fun PatchableToBitmap(
+    modifier: Modifier = Modifier,
+    patchable: @Composable () -> Unit,
+) {
+    var image by remember { mutableStateOf<ImageBitmap?>(null) }
+
+    Box(modifier = modifier.fillMaxWidth()) {
+        // Compose the content through the composable utility; it will invoke the callback when ready.
+        CaptureToBitmap(
+            modifier = Modifier.fillMaxWidth(),
+            autoCapture = true,
+            onBitmap = { img -> image = img },
+            content = patchable
+        )
+
+        val b = image
+        if (b != null) {
+            Image(bitmap = b, contentDescription = "patch bitmap", modifier = Modifier.fillMaxWidth())
+        } else {
+            CircularProgressIndicator()
+        }
+    }
+}

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBoundingBox.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBoundingBox.kt
@@ -1,0 +1,23 @@
+package de.berlindroid.zepatch.ui
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PatchableBoundingBox(
+    modifier: Modifier = Modifier,
+    patchable: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier.border(
+            width = 1.dp,
+            color = Color.Black,
+        ),
+    ) {
+        patchable()
+    }
+}

--- a/app/src/main/java/de/berlindroid/zepatch/ui/SafeArea.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/SafeArea.kt
@@ -1,0 +1,22 @@
+package de.berlindroid.zepatch.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Common SafeArea wrapper to provide consistent padding around patchable content.
+ */
+@Composable
+fun SafeArea(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier.padding(32.dp),
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
@@ -1,0 +1,73 @@
+package de.berlindroid.zepatch.utils
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import kotlinx.coroutines.launch
+
+/**
+ * Composable utility that renders [content] into a compositing graphics layer and can
+ * capture it into an [ImageBitmap].
+ *
+ * How it works:
+ * - We draw the composable's content into a remembered graphics layer using drawWithContent.
+ * - We then draw that content normally so it appears on screen.
+ * - We can capture the current pixels of that layer via graphicsLayer.toImageBitmap().
+ *
+ * Behavior:
+ * - If [autoCapture] is true, it will capture once on first composition and invoke [onBitmap].
+ * - It also supports manual capture by tapping the content (clickable), which will invoke [onBitmap].
+ */
+@Composable
+fun CaptureToBitmap(
+    modifier: Modifier = Modifier,
+    autoCapture: Boolean = true,
+    onBitmap: (ImageBitmap) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val graphicsLayer = rememberGraphicsLayer()
+    var captured by remember { mutableStateOf(false) }
+
+    // Optionally capture once after first composition
+    LaunchedEffect(autoCapture) {
+        if (autoCapture && !captured) {
+            captured = true
+            val capturedImage = graphicsLayer.toImageBitmap()
+            onBitmap(capturedImage)
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .drawWithContent {
+                // Record content drawing into the graphics layer
+                graphicsLayer.record {
+                    this@drawWithContent.drawContent()
+                }
+                // Draw the content normally so it appears on screen
+                this.drawContent()
+            }
+            .clickable {
+                coroutineScope.launch {
+                    val bitmap = graphicsLayer.toImageBitmap()
+                    onBitmap(bitmap)
+                }
+            }
+            .background(Color.White)
+    ) {
+        content()
+    }
+}


### PR DESCRIPTION
Introduces a new rendering mode that captures patchable composables as bitmaps.

Moves the SafeArea composable to the ui package for better organisation and reusability.

Fixes Issue #11
