### PR TITLE
State hoist and prep for Wizard UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# Ignore Junie working files
+.junie/guidelines.md

--- a/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import de.berlindroid.zepatch.PatchablePreviewMode.*
@@ -173,6 +174,9 @@ private fun PatchableDetail(
     onBackClick: () -> Unit,
     patchable: @Composable () -> Unit,
 ) {
+    var imageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+    var reducedImageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -224,13 +228,20 @@ private fun PatchableDetail(
             when (currentMode) {
                 COMPOSABLE -> PatchableBoundingBox(patchable = patchable)
 
-                BITMAP -> PatchableToBitmap(patchable = patchable)
-
-                REDUCED_BITMAP -> PatchableToReducedBitmap(
+                BITMAP -> PatchableToBitmap(
+                    onBitmap = { img -> imageBitmap = img },
                     patchable = patchable
                 )
 
-                STITCHES -> BitmapToStitches(patchable = patchable, name = name)
+                REDUCED_BITMAP -> PatchableToReducedBitmap(
+                    image = imageBitmap,
+                    onReducedBitmap = { img -> reducedImageBitmap = img },
+                )
+
+                STITCHES -> BitmapToStitches(
+                    reducedImageBitmap = reducedImageBitmap,
+                    name = name
+                )
             }
         }
     }

--- a/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaf
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -176,6 +177,7 @@ private fun PatchableDetail(
 ) {
     var imageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
     var reducedImageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+    var colorCount by remember { mutableIntStateOf(3) }
 
     Scaffold(
         modifier = modifier,
@@ -235,6 +237,8 @@ private fun PatchableDetail(
 
                 REDUCED_BITMAP -> PatchableToReducedBitmap(
                     image = imageBitmap,
+                    colorCount = colorCount,
+                    onColorCountChanged = { count -> colorCount = count },
                     onReducedBitmap = { img -> reducedImageBitmap = img },
                 )
 

--- a/app/src/main/java/de/berlindroid/zepatch/patchable/Demo.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/patchable/Demo.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -23,7 +22,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
@@ -11,22 +11,30 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.core.graphics.scale
 import com.embroidermodder.punching.reduceColors
 import de.berlindroid.zepatch.stiches.StitchToPES
@@ -42,6 +50,7 @@ fun BitmapToStitches(
 ) {
     val context = LocalContext.current
     var bytes by remember { mutableStateOf<ByteArray?>(null) }
+    var capture by remember { mutableStateOf(false) }
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -51,10 +60,14 @@ fun BitmapToStitches(
 
     var image by remember { mutableStateOf<ImageBitmap?>(null) }
 
-    Box(modifier = modifier.fillMaxWidth()) {
-        // Compose the content through the composable utility; it will invoke the callback when ready.
+    Column(modifier = modifier.fillMaxWidth()) {
+        Button(onClick = {
+            image = null
+            capture = true
+        }) { Text("Do it") }  // Compose the content through the composable utility; it will invoke the callback when ready.
         CaptureToBitmap(
             modifier = Modifier.fillMaxWidth(),
+            capture = capture,
             onBitmap = { img ->
                 // TODO: PARRALELEIZE & VMIZE
                 val aspect = img.width / img.height.toFloat()
@@ -90,6 +103,7 @@ fun BitmapToStitches(
                         .scale(decoded.width * 2, decoded.height * 2)
                         .asImageBitmap()
                 }
+                capture = false
             },
             content = patchable
         )
@@ -160,6 +174,24 @@ private fun savePesAfterSelection(context: Context, result: ActivityResult, byte
                 "Done writing file! Happy embroidering 🪡",
                 Toast.LENGTH_SHORT
             ).show()
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BitmapToStitchesPreview() {
+    BitmapToStitches(Modifier, "Demo") {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.Blue)
+        ) {
+            Text(
+                "Preview Content",
+                modifier = Modifier.padding(16.dp),
+                color = Color.White
+            )
         }
     }
 }

--- a/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.graphics.scale
 import de.berlindroid.zepatch.stiches.StitchToPES
 import de.berlindroid.zepatch.stiches.StitchToPES.createEmbroideryFromBitmap
@@ -162,21 +163,10 @@ private fun savePesAfterSelection(context: Context, result: ActivityResult, byte
     }
 }
 
-//@Preview(showBackground = true)
-//@Composable
-//private fun BitmapToStitchesPreview() {
-//    BitmapToStitches(Modifier, "Demo") {
-//        Box(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .background(Color.Blue)
-//        ) {
-//            Text(
-//                "Preview Content",
-//                modifier = Modifier.padding(16.dp),
-//                color = Color.White
-//            )
-//        }
-//    }
-//}
+@Preview
+@Composable
+fun BitmapToStitchesPreview() {
+    val imageBitmap = ImageBitmap(width = 100, height = 100) // Replace with a real ImageBitmap if needed
+    BitmapToStitches(reducedImageBitmap = imageBitmap, name = "MyPatch")
+}
 

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
@@ -2,8 +2,11 @@ package de.berlindroid.zepatch.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,12 +26,21 @@ fun PatchableToBitmap(
     patchable: @Composable () -> Unit,
 ) {
     var image by remember { mutableStateOf<ImageBitmap?>(null) }
+    var capture by remember { mutableStateOf(false) }
 
-    Box(modifier = modifier.fillMaxWidth()) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Button(onClick = {
+            image = null
+            capture = true
+        }) { Text("Do it") }
         // Compose the content through the composable utility; it will invoke the callback when ready.
         CaptureToBitmap(
             modifier = Modifier.fillMaxWidth(),
-            onBitmap = { img -> image = img },
+            capture = capture,
+            onBitmap = { img ->
+                image = img
+                capture = false
+            },
             content = patchable
         )
 
@@ -42,3 +54,5 @@ fun PatchableToBitmap(
 
     }
 }
+
+

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
@@ -1,7 +1,6 @@
 package de.berlindroid.zepatch.ui
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Button
@@ -23,6 +22,7 @@ import de.berlindroid.zepatch.utils.CaptureToBitmap
 @Composable
 fun PatchableToBitmap(
     modifier: Modifier = Modifier,
+    onBitmap: (ImageBitmap) -> Unit = {},
     patchable: @Composable () -> Unit,
 ) {
     var image by remember { mutableStateOf<ImageBitmap?>(null) }
@@ -50,6 +50,7 @@ fun PatchableToBitmap(
                 contentDescription = "patch bitmap",
                 modifier = Modifier.fillMaxWidth()
             )
+            onBitmap(it)
         } ?: CircularProgressIndicator()
 
     }

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
@@ -26,20 +26,20 @@ fun PatchableToBitmap(
     patchable: @Composable () -> Unit,
 ) {
     var image by remember { mutableStateOf<ImageBitmap?>(null) }
-    var capture by remember { mutableStateOf(false) }
+    var shouldCapture by remember { mutableStateOf(false) }
 
     Column(modifier = modifier.fillMaxWidth()) {
         Button(onClick = {
             image = null
-            capture = true
+            shouldCapture = true
         }) { Text("Do it") }
         // Compose the content through the composable utility; it will invoke the callback when ready.
         CaptureToBitmap(
             modifier = Modifier.fillMaxWidth(),
-            capture = capture,
+            shouldCapture = shouldCapture,
             onBitmap = { img ->
                 image = img
-                capture = false
+                shouldCapture = false
             },
             content = patchable
         )

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
@@ -2,9 +2,13 @@ package de.berlindroid.zepatch.ui
 
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -17,8 +21,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
 import androidx.core.graphics.scale
 import androidx.core.text.isDigitsOnly
 import com.embroidermodder.punching.reduceColors
@@ -29,24 +36,32 @@ fun PatchableToReducedBitmap(
     modifier: Modifier = Modifier,
     patchable: @Composable () -> Unit,
 ) {
+
     var image by remember { mutableStateOf<ImageBitmap?>(null) }
     var colorCount by remember { mutableStateOf<Int>(3) }
+    var capture by remember { mutableStateOf(false) }
 
-    CaptureToBitmap(
-        modifier = Modifier.fillMaxWidth(),
-        onBitmap = { img ->
-            // TODO: PARRALELEIZE & VMIZE
-            val aspect = img.width / img.height.toFloat()
-            image = img.asAndroidBitmap()
-                .copy(Bitmap.Config.ARGB_8888, false)
-                .scale((512 * aspect).toInt(), 512, false)
-                .reduceColors(colorCount)
-                .asImageBitmap()
-        },
-        content = patchable
-    )
+    Column(modifier = modifier.fillMaxWidth()) {
+        Button(onClick = {
+            image = null
+            capture = true
+        }) { Text("Do it") }
+        CaptureToBitmap(
+            modifier = Modifier.fillMaxWidth(),
+            capture = capture,
+            onBitmap = { img ->
+                // TODO: PARRALELEIZE & VMIZE
+                val aspect = img.width / img.height.toFloat()
+                image = img.asAndroidBitmap()
+                    .copy(Bitmap.Config.ARGB_8888, false)
+                    .scale((512 * aspect).toInt(), 512, false)
+                    .reduceColors(colorCount)
+                    .asImageBitmap()
+                capture = false
+            },
+            content = patchable
+        )
 
-    Box(modifier = modifier.fillMaxWidth()) {
         TextField(
             value = "$colorCount",
             onValueChange = {
@@ -70,5 +85,24 @@ fun PatchableToReducedBitmap(
                 modifier = Modifier.fillMaxWidth()
             )
         } ?: CircularProgressIndicator()
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun PatchableToReducedBitmapPreview() {
+    PatchableToReducedBitmap {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.Blue)
+        ) {
+            Text(
+                "Preview Content",
+                modifier = Modifier.padding(16.dp),
+                color = Color.White
+            )
+        }
     }
 }

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.core.graphics.scale
 import androidx.core.text.isDigitsOnly
+import androidx.compose.ui.tooling.preview.Preview
 import com.embroidermodder.punching.reduceColors
 import kotlinx.coroutines.launch
 
@@ -88,10 +89,15 @@ fun PatchableToReducedBitmap(
     }
 }
 
+@Preview
+@Composable
+fun PatchableToReducedBitmapPreview() {
+    PatchableToReducedBitmap(
+        image = ImageBitmap(width = 100, height = 100), // Example ImageBitmap
+        colorCount = 5,
+        onReducedBitmap = {},
+        onColorCountChanged = {}
+    )
+}
 
-//@Preview(showBackground = true)
-//@Composable
-//private fun PatchableToReducedBitmapPreview() {
-//    PatchableToReducedBitmap()
-//
-//}
+

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -31,11 +30,12 @@ import kotlinx.coroutines.launch
 fun PatchableToReducedBitmap(
     modifier: Modifier = Modifier,
     image: ImageBitmap? = null,
+    colorCount: Int = 3,
     onReducedBitmap: (ImageBitmap) -> Unit = {},
+    onColorCountChanged: (Int) -> Unit = {}
 ) {
 
     var reducedImage by remember { mutableStateOf<ImageBitmap?>(null) }
-    var colorCount by remember { mutableIntStateOf(3) }
     val coroutineScope = rememberCoroutineScope()
 
     Column(modifier = modifier.fillMaxWidth()) {
@@ -65,7 +65,7 @@ fun PatchableToReducedBitmap(
             value = "$colorCount",
             onValueChange = {
                 if (it.isNotBlank() && it.isDigitsOnly()) {
-                    colorCount = it.toInt()
+                    onColorCountChanged(it.toInt())
                 } else {
                     colorCount
                 }

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
@@ -24,6 +25,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.core.graphics.scale
 import androidx.core.text.isDigitsOnly
 import com.embroidermodder.punching.reduceColors
+import kotlinx.coroutines.launch
 
 @Composable
 fun PatchableToReducedBitmap(
@@ -34,6 +36,7 @@ fun PatchableToReducedBitmap(
 
     var reducedImage by remember { mutableStateOf<ImageBitmap?>(null) }
     var colorCount by remember { mutableIntStateOf(3) }
+    val coroutineScope = rememberCoroutineScope()
 
     Column(modifier = modifier.fillMaxWidth()) {
         image?.let {
@@ -45,14 +48,16 @@ fun PatchableToReducedBitmap(
         }
         Button(onClick = {
             // TODO: PARRALELEIZE & VMIZE
-            reducedImage = null
-            image?.let {
-                val aspect = it.width / it.height.toFloat()
-                reducedImage = it.asAndroidBitmap()
-                    .copy(Bitmap.Config.ARGB_8888, false)
-                    .scale((512 * aspect).toInt(), 512, false)
-                    .reduceColors(colorCount)
-                    .asImageBitmap()
+            coroutineScope.launch {
+                reducedImage = null
+                image?.let {
+                    val aspect = it.width / it.height.toFloat()
+                    reducedImage = it.asAndroidBitmap()
+                        .copy(Bitmap.Config.ARGB_8888, false)
+                        .scale((512 * aspect).toInt(), 512, false)
+                        .reduceColors(colorCount)
+                        .asImageBitmap()
+                }
             }
         }) { Text("Do it") }
 

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToReducedBitmap.kt
@@ -2,11 +2,8 @@ package de.berlindroid.zepatch.ui
 
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -14,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -21,46 +19,42 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import androidx.core.graphics.scale
 import androidx.core.text.isDigitsOnly
 import com.embroidermodder.punching.reduceColors
-import de.berlindroid.zepatch.utils.CaptureToBitmap
 
 @Composable
 fun PatchableToReducedBitmap(
     modifier: Modifier = Modifier,
-    patchable: @Composable () -> Unit,
+    image: ImageBitmap? = null,
+    onReducedBitmap: (ImageBitmap) -> Unit = {},
 ) {
 
-    var image by remember { mutableStateOf<ImageBitmap?>(null) }
-    var colorCount by remember { mutableStateOf<Int>(3) }
-    var capture by remember { mutableStateOf(false) }
+    var reducedImage by remember { mutableStateOf<ImageBitmap?>(null) }
+    var colorCount by remember { mutableIntStateOf(3) }
 
     Column(modifier = modifier.fillMaxWidth()) {
+        image?.let {
+            Image(
+                bitmap = it,
+                contentDescription = "patch bitmap",
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
         Button(onClick = {
-            image = null
-            capture = true
-        }) { Text("Do it") }
-        CaptureToBitmap(
-            modifier = Modifier.fillMaxWidth(),
-            capture = capture,
-            onBitmap = { img ->
-                // TODO: PARRALELEIZE & VMIZE
-                val aspect = img.width / img.height.toFloat()
-                image = img.asAndroidBitmap()
+            // TODO: PARRALELEIZE & VMIZE
+            reducedImage = null
+            image?.let {
+                val aspect = it.width / it.height.toFloat()
+                reducedImage = it.asAndroidBitmap()
                     .copy(Bitmap.Config.ARGB_8888, false)
                     .scale((512 * aspect).toInt(), 512, false)
                     .reduceColors(colorCount)
                     .asImageBitmap()
-                capture = false
-            },
-            content = patchable
-        )
+            }
+        }) { Text("Do it") }
 
         TextField(
             value = "$colorCount",
@@ -78,31 +72,21 @@ fun PatchableToReducedBitmap(
             )
         )
 
-        image?.let {
+        reducedImage?.let {
             Image(
                 bitmap = it,
                 contentDescription = "patch bitmap",
                 modifier = Modifier.fillMaxWidth()
             )
+            onReducedBitmap(it)
         } ?: CircularProgressIndicator()
     }
 }
 
 
-@Preview(showBackground = true)
-@Composable
-private fun PatchableToReducedBitmapPreview() {
-    PatchableToReducedBitmap {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(Color.Blue)
-        ) {
-            Text(
-                "Preview Content",
-                modifier = Modifier.padding(16.dp),
-                color = Color.White
-            )
-        }
-    }
-}
+//@Preview(showBackground = true)
+//@Composable
+//private fun PatchableToReducedBitmapPreview() {
+//    PatchableToReducedBitmap()
+//
+//}

--- a/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
@@ -18,27 +18,27 @@ import androidx.compose.ui.graphics.rememberGraphicsLayer
 import kotlinx.coroutines.launch
 
 /**
- * Composable utility that renders [content] into a compositing graphics layer and can
- * capture it into an [ImageBitmap].
+ * A composable function that captures the drawn content of its child composables into a bitmap
+ * when triggered. This allows developers to programmatically generate an `ImageBitmap`
+ * from the rendered UI content.
  *
- * How it works:
- * - We draw the composable's content into a remembered graphics layer using drawWithContent.
- * - We then draw that content normally so it appears on screen.
- * - We can capture the current pixels of that layer via graphicsLayer.toImageBitmap().
- *
- * Behavior:
- * - If [autoCapture] is true, it will capture once on first composition and invoke [onBitmap].
- * - It also supports manual capture by tapping the content (clickable), which will invoke [onBitmap].
+ * @param modifier A [Modifier] instance to apply to this composable for layout or styling configurations.
+ * @param capture A flag to trigger the capture process when set to `true`. The content will be converted
+ *                to a bitmap and passed to the `onBitmap` callback.
+ * @param onBitmap A callback triggered with the generated [ImageBitmap] once the content has been
+ *                 successfully captured.
+ * @param content A lambda expression containing the composable content to be rendered and captured
+ *                into the output bitmap.
  */
 @Composable
 fun CaptureToBitmap(
     modifier: Modifier = Modifier,
+    capture: Boolean = false,
     onBitmap: (ImageBitmap) -> Unit,
     content: @Composable () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
     val graphicsLayer = rememberGraphicsLayer()
-
     Box(
         modifier = modifier
             .drawWithContent {
@@ -47,14 +47,16 @@ fun CaptureToBitmap(
                     this@drawWithContent.drawContent()
                 }
             }
-            .clickable {
+            .background(Color.Transparent)
+    ) {
+        LaunchedEffect(capture) {
+            if (capture) {
                 coroutineScope.launch {
                     val bitmap = graphicsLayer.toImageBitmap()
                     onBitmap(bitmap)
                 }
             }
-            .background(Color.Transparent)
-    ) {
+        }
         content()
     }
 }

--- a/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
@@ -1,15 +1,10 @@
 package de.berlindroid.zepatch.utils
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
@@ -23,7 +18,7 @@ import kotlinx.coroutines.launch
  * from the rendered UI content.
  *
  * @param modifier A [Modifier] instance to apply to this composable for layout or styling configurations.
- * @param capture A flag to trigger the capture process when set to `true`. The content will be converted
+ * @param shouldCapture A flag to trigger the capture process when set to `true`. The content will be converted
  *                to a bitmap and passed to the `onBitmap` callback.
  * @param onBitmap A callback triggered with the generated [ImageBitmap] once the content has been
  *                 successfully captured.
@@ -33,7 +28,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun CaptureToBitmap(
     modifier: Modifier = Modifier,
-    capture: Boolean = false,
+    shouldCapture: Boolean = false,
     onBitmap: (ImageBitmap) -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -49,8 +44,8 @@ fun CaptureToBitmap(
             }
             .background(Color.Transparent)
     ) {
-        LaunchedEffect(capture) {
-            if (capture) {
+        LaunchedEffect(shouldCapture) {
+            if (shouldCapture) {
                 coroutineScope.launch {
                     val bitmap = graphicsLayer.toImageBitmap()
                     onBitmap(bitmap)


### PR DESCRIPTION
This PR refactors the bitmap processing pipeline by hoisting interim output state up into the PatchableDetail Composable. This allows sub-steps to only do the part they are responsible for and allows the user to jump back to a previous points and rerun a step. Each action is also triggered by an arguably ugly `Do it` button.

These changes are necessary to get the navigation flow into a state that I can make a prettier wizard interface in a subsequent PR. This new flow also allows future changes for more interactive patchables.

Links to #33 more PRs to come

