### PR TITLE
Refactors detail view to use ViewModel

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ dependencies {
     implementation(libs.androidx.adaptive)
     implementation(libs.androidx.adaptive.layout)
     implementation(libs.androidx.adaptive.navigation)
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
+    implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     // Patch annotations + processor
     implementation(project(":patch-annotations"))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,8 @@ dependencies {
     implementation(libs.androidx.adaptive)
     implementation(libs.androidx.adaptive.layout)
     implementation(libs.androidx.adaptive.navigation)
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
 
     // Patch annotations + processor
     implementation(project(":patch-annotations"))

--- a/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
@@ -244,8 +244,7 @@ private fun PatchableDetail(
                 onBitmapUpdated = viewModel::updateBitmap,
                 onColorCountUpdated = viewModel::updateColorCount,
                 computeReducedBitmap = viewModel::computeReducedBitmap,
-                onEmbroideryUpdated = viewModel::updateEmbroidery,
-                patchable
+                patchable = patchable
             )
 
             WizardButtons(
@@ -276,7 +275,6 @@ private fun WizardContent(
     onBitmapUpdated: (ImageBitmap) -> Unit,
     onColorCountUpdated: (Int) -> Unit,
     computeReducedBitmap: () -> Unit,
-    onEmbroideryUpdated: (ByteArray, ImageBitmap) -> Unit,
     patchable: @Composable (Boolean, (ImageBitmap) -> Unit) -> Unit,
 ) {
     Card(
@@ -302,11 +300,15 @@ private fun WizardContent(
             )
 
             STITCHES -> reducedImageBitmap?.multiLet(reducedHistogram) { img, histo ->
+                val vm: WizardViewModel = lifecycleViewModel()
+                val ui by vm.uiState.collectAsStateWithLifecycle()
                 BitmapToStitches(
                     reducedImageBitmap = img,
                     reducedHistogram = histo,
                     name = name,
-                    onEmbroidery = onEmbroideryUpdated
+                    onCreateEmbroidery = { n, b, h -> vm.createEmbroidery(n, b, h) },
+                    previewImage = ui.embroideryPreviewImage,
+                    creatingEmbroidery = ui.creatingEmbroidery,
                 )
             }
         }

--- a/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.adaptive.navigation.NavigableListDetailPaneSca
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -198,6 +199,11 @@ private fun PatchableDetail(
 
     val viewModel: WizardViewModel = lifecycleViewModel()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // Reset wizard state when a different patchable is opened
+    LaunchedEffect(name) {
+        viewModel.reset()
+    }
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()

--- a/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
@@ -74,7 +74,6 @@ import de.berlindroid.zepatch.utils.uppercaseWords
 import kotlinx.coroutines.launch
 import androidx.lifecycle.viewmodel.compose.viewModel as lifecycleViewModel
 
-
 enum class PatchablePreviewMode {
     COMPOSABLE, BITMAP, REDUCED_BITMAP, STITCHES
 }
@@ -239,7 +238,6 @@ private fun PatchableDetail(
                 onBitmapUpdated = viewModel::updateBitmap,
                 onColorCountUpdated = viewModel::updateColorCount,
                 computeReducedBitmap = viewModel::computeReducedBitmap,
-                onReducedUpdated = viewModel::setReducedResult,
                 onEmbroideryUpdated = viewModel::updateEmbroidery,
                 patchable
             )
@@ -253,7 +251,7 @@ private fun PatchableDetail(
                 launcher
             ) {
                 viewModel.setPreviewMode(it)
-                if (it == PatchablePreviewMode.REDUCED_BITMAP) {
+                if (it == REDUCED_BITMAP) {
                     viewModel.computeReducedBitmap()
                 }
             }
@@ -272,7 +270,6 @@ private fun WizardContent(
     onBitmapUpdated: (ImageBitmap) -> Unit,
     onColorCountUpdated: (Int) -> Unit,
     computeReducedBitmap: () -> Unit,
-    onReducedUpdated: (ImageBitmap, Histogram) -> Unit,
     onEmbroideryUpdated: (ByteArray, ImageBitmap) -> Unit,
     patchable: @Composable (Boolean, (ImageBitmap) -> Unit) -> Unit,
 ) {

--- a/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
@@ -52,16 +52,13 @@ import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaf
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.embroidermodder.punching.Histogram
 import de.berlindroid.zepatch.PatchablePreviewMode.BITMAP
 import de.berlindroid.zepatch.PatchablePreviewMode.COMPOSABLE
@@ -75,9 +72,10 @@ import de.berlindroid.zepatch.ui.theme.ZePatchTheme
 import de.berlindroid.zepatch.utils.multiLet
 import de.berlindroid.zepatch.utils.uppercaseWords
 import kotlinx.coroutines.launch
+import androidx.lifecycle.viewmodel.compose.viewModel as lifecycleViewModel
 
 
-private enum class PatchablePreviewMode {
+enum class PatchablePreviewMode {
     COMPOSABLE, BITMAP, REDUCED_BITMAP, STITCHES
 }
 
@@ -197,18 +195,15 @@ private fun PatchableDetail(
     onBackClick: () -> Unit,
     patchable: @Composable (Boolean, (ImageBitmap) -> Unit) -> Unit,
 ) {
-    var imageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
-    var reducedImageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
-    var reducedHistogram by remember { mutableStateOf<Histogram?>(null) }
-    var colorCount by remember { mutableIntStateOf(3) }
-    var embroideryData by remember { mutableStateOf<ByteArray?>(null) }
-    var embroideryPreviewImage by remember { mutableStateOf<ImageBitmap?>(null) }
-
     val context = LocalContext.current
+
+    val viewModel: WizardViewModel = lifecycleViewModel()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
     ) { result ->
-        savePesAfterSelection(context, result, embroideryData)
+        savePesAfterSelection(context, result, uiState.embroideryData)
     }
 
     Scaffold(
@@ -232,38 +227,35 @@ private fun PatchableDetail(
         Column(
             modifier = Modifier.padding(innerPadding),
         ) {
-            var currentMode by remember { mutableStateOf(COMPOSABLE) }
-
-            ProgressPills(imageBitmap, reducedImageBitmap, currentMode)
+            ProgressPills(uiState.imageBitmap, uiState.reducedImageBitmap, uiState.previewMode)
 
             WizardContent(
-                currentMode,
-                imageBitmap,
-                colorCount,
-                reducedImageBitmap,
-                reducedHistogram,
+                uiState.previewMode,
+                uiState.imageBitmap,
+                uiState.colorCount,
+                uiState.reducedImageBitmap,
+                uiState.reducedHistogram,
                 name,
-                onBitmapUpdated = { imageBitmap = it },
-                onColorCountUpdated = { colorCount = it },
-                onReducedUpdated = { img, histo ->
-                    reducedImageBitmap = img;reducedHistogram = histo
-                },
-                onEmbroideryUpdated = { data, preview ->
-                    embroideryData = data
-                    embroideryPreviewImage = preview
-                },
+                onBitmapUpdated = viewModel::updateBitmap,
+                onColorCountUpdated = viewModel::updateColorCount,
+                computeReducedBitmap = viewModel::computeReducedBitmap,
+                onReducedUpdated = viewModel::setReducedResult,
+                onEmbroideryUpdated = viewModel::updateEmbroidery,
                 patchable
             )
 
             WizardButtons(
-                currentMode,
-                imageBitmap,
-                reducedImageBitmap,
-                embroideryData,
+                uiState.previewMode,
+                uiState.imageBitmap,
+                uiState.reducedImageBitmap,
+                uiState.embroideryData,
                 name,
                 launcher
             ) {
-                currentMode = it
+                viewModel.setPreviewMode(it)
+                if (it == PatchablePreviewMode.REDUCED_BITMAP) {
+                    viewModel.computeReducedBitmap()
+                }
             }
         }
     }
@@ -279,6 +271,7 @@ private fun WizardContent(
     name: String,
     onBitmapUpdated: (ImageBitmap) -> Unit,
     onColorCountUpdated: (Int) -> Unit,
+    computeReducedBitmap: () -> Unit,
     onReducedUpdated: (ImageBitmap, Histogram) -> Unit,
     onEmbroideryUpdated: (ByteArray, ImageBitmap) -> Unit,
     patchable: @Composable (Boolean, (ImageBitmap) -> Unit) -> Unit,
@@ -301,7 +294,8 @@ private fun WizardContent(
                 image = imageBitmap,
                 colorCount = colorCount,
                 onColorCountChanged = onColorCountUpdated,
-                onReduced = onReducedUpdated,
+                computeReducedBitmap = computeReducedBitmap,
+                reducedImage = reducedImageBitmap,
             )
 
             STITCHES -> reducedImageBitmap?.multiLet(reducedHistogram) { img, histo ->

--- a/app/src/main/java/de/berlindroid/zepatch/WizardViewModel.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/WizardViewModel.kt
@@ -34,6 +34,11 @@ class WizardViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(UIState())
     val uiState: StateFlow<UIState> = _uiState.asStateFlow()
 
+    /** Resets the whole wizard state back to initial defaults. */
+    fun reset() {
+        _uiState.value = UIState()
+    }
+
     fun setPreviewMode(mode: PatchablePreviewMode) {
         _uiState.value = _uiState.value.copy(previewMode = mode)
     }

--- a/app/src/main/java/de/berlindroid/zepatch/WizardViewModel.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/WizardViewModel.kt
@@ -1,0 +1,87 @@
+package de.berlindroid.zepatch
+
+import android.graphics.Bitmap
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.core.graphics.scale
+import com.embroidermodder.punching.Histogram
+import com.embroidermodder.punching.reduceColors
+import de.berlindroid.zepatch.PatchablePreviewMode.COMPOSABLE
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel to manage the Wizard screen state.
+ */
+class WizardViewModel : ViewModel() {
+
+    data class UIState(
+        val imageBitmap: ImageBitmap? = null,
+        val reducedImageBitmap: ImageBitmap? = null,
+        val reducedHistogram: Histogram? = null,
+        val colorCount: Int = 3,
+        val embroideryData: ByteArray? = null,
+        val embroideryPreviewImage: ImageBitmap? = null,
+        val previewMode: PatchablePreviewMode = COMPOSABLE,
+    )
+
+    private val _uiState = MutableStateFlow(UIState())
+    val uiState: StateFlow<UIState> = _uiState.asStateFlow()
+
+    fun setPreviewMode(mode: PatchablePreviewMode) {
+        _uiState.value = _uiState.value.copy(previewMode = mode)
+    }
+
+    fun updateColorCount(count: Int) {
+        _uiState.value = _uiState.value.copy(colorCount = count)
+    }
+
+    fun updateBitmap(bitmap: ImageBitmap) {
+        _uiState.value = _uiState.value.copy(
+            imageBitmap = bitmap,
+            // Reset downstream results when source bitmap changes
+            reducedImageBitmap = null,
+            reducedHistogram = null,
+            embroideryData = null,
+            embroideryPreviewImage = null,
+        )
+    }
+
+    fun computeReducedBitmap() {
+        val state = _uiState.value
+        val image = state.imageBitmap ?: return
+        val colorCount = state.colorCount
+        viewModelScope.launch(Dispatchers.IO) {
+            val aspect = image.width / image.height.toFloat()
+            val (reducedBmp, histogram) = image.asAndroidBitmap()
+                .copy(Bitmap.Config.ARGB_8888, false)
+                .scale((512 * aspect).toInt(), 512, false)
+                .reduceColors(colorCount)
+
+            _uiState.value = _uiState.value.copy(
+                reducedImageBitmap = reducedBmp.asImageBitmap(),
+                reducedHistogram = histogram,
+            )
+        }
+    }
+
+    fun updateEmbroidery(data: ByteArray, preview: ImageBitmap) {
+        _uiState.value = _uiState.value.copy(
+            embroideryData = data,
+            embroideryPreviewImage = preview,
+        )
+    }
+
+    fun setReducedResult(image: ImageBitmap, histogram: Histogram) {
+        _uiState.value = _uiState.value.copy(
+            reducedImageBitmap = image,
+            reducedHistogram = histogram,
+        )
+    }
+}

--- a/app/src/main/java/de/berlindroid/zepatch/WizardViewModel.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/WizardViewModel.kt
@@ -1,12 +1,12 @@
 package de.berlindroid.zepatch
 
 import android.graphics.Bitmap
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.graphics.scale
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.embroidermodder.punching.Histogram
 import com.embroidermodder.punching.reduceColors
 import de.berlindroid.zepatch.PatchablePreviewMode.COMPOSABLE
@@ -83,10 +83,4 @@ class WizardViewModel : ViewModel() {
         )
     }
 
-    fun setReducedResult(image: ImageBitmap, histogram: Histogram) {
-        _uiState.value = _uiState.value.copy(
-            reducedImageBitmap = image,
-            reducedHistogram = histogram,
-        )
-    }
 }

--- a/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
@@ -1,7 +1,5 @@
 package de.berlindroid.zepatch.ui
 
-import android.graphics.BitmapFactory
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,25 +7,12 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asAndroidBitmap
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.core.graphics.scale
 import com.embroidermodder.punching.Histogram
 import com.embroidermodder.punching.colorHistogram
-import de.berlindroid.zepatch.stiches.StitchToPES
-import de.berlindroid.zepatch.stiches.StitchToPES.createEmbroideryFromBitmap
-import de.berlindroid.zepatch.utils.multiLet
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 @Composable
 fun BitmapToStitches(
@@ -35,12 +20,10 @@ fun BitmapToStitches(
     reducedImageBitmap: ImageBitmap,
     reducedHistogram: Histogram,
     name: String,
-    onEmbroidery: (pes: ByteArray, preview: ImageBitmap) -> Unit
+    onCreateEmbroidery: (name: String, bitmap: ImageBitmap, histogram: Histogram) -> Unit,
+    previewImage: ImageBitmap?,
+    creatingEmbroidery: Boolean,
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    val context = LocalContext.current
-    var displayImage by remember { mutableStateOf<ImageBitmap?>(null) }
-
     Column(modifier = modifier.fillMaxWidth()) {
         Image(
             bitmap = reducedImageBitmap,
@@ -48,64 +31,34 @@ fun BitmapToStitches(
             modifier = Modifier.fillMaxWidth()
         )
         Button(onClick = {
-            coroutineScope.launch(Dispatchers.IO) {
-                val aspect = reducedImageBitmap.width / reducedImageBitmap.height.toFloat()
-                val embroidery = createEmbroideryFromBitmap(
-                    name,
-                    bitmap = reducedImageBitmap.asAndroidBitmap(),
-                    histogram = reducedHistogram,
-                    mmWidth = 500f * aspect,
-                    mmHeight = 500f,
-                    mmDensityX = 4f,
-                    mmDensityY = 2f,
-                )
+            onCreateEmbroidery(name, reducedImageBitmap, reducedHistogram)
+        }) { Text("Do it") }
 
-                val pes = StitchToPES.convert(context, embroidery)
-                if (pes == null || pes.isEmpty()) {
-                    Log.e("EMBNO", "No pes found.")
-                }
-
-                val png = StitchToPES.convert(context, embroidery, "png")
-                displayImage = if (png == null || png.isEmpty()) {
-                    Log.e("PNGNO", "No png returned.")
-                    null
-                } else {
-                    val decoded = BitmapFactory.decodeByteArray(png, 0, png.size)
-
-                    decoded
-                        .scale(decoded.width * 2, decoded.height * 2)
-                        .asImageBitmap()
-                }
-
-                pes?.multiLet(displayImage) { pes, image ->
-                    onEmbroidery(
-                        pes, image
-                    )
-                }
-            }
-        }) { Text("Do it") }  // Compose the content through the composable utility; it will invoke the callback when ready.
-
-        displayImage?.let {
+        val preview = previewImage
+        if (preview != null) {
             Image(
-                bitmap = it,
+                bitmap = preview,
                 contentDescription = "patch bitmap",
                 modifier = Modifier.fillMaxWidth()
             )
-        } ?: CircularProgressIndicator()
+        } else if (creatingEmbroidery) {
+            CircularProgressIndicator()
+        }
     }
 }
 
 @Preview
 @Composable
 fun BitmapToStitchesPreview() {
-    val imageBitmap =
-        ImageBitmap(width = 100, height = 100) // Replace with a real ImageBitmap if needed
+    val imageBitmap = ImageBitmap(width = 100, height = 100)
     val histogram = imageBitmap.asAndroidBitmap().colorHistogram()
     BitmapToStitches(
         reducedImageBitmap = imageBitmap,
         reducedHistogram = histogram,
         name = "MyPatch",
-        onEmbroidery = { _, _ -> }
+        onCreateEmbroidery = { _, _, _ -> },
+        previewImage = null,
+        creatingEmbroidery = false,
     )
 }
 

--- a/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
@@ -29,7 +29,6 @@ import de.berlindroid.zepatch.utils.multiLet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-
 @Composable
 fun BitmapToStitches(
     modifier: Modifier = Modifier,
@@ -99,7 +98,8 @@ fun BitmapToStitches(
 @Preview
 @Composable
 fun BitmapToStitchesPreview() {
-    val imageBitmap = ImageBitmap(width = 100, height = 100) // Replace with a real ImageBitmap if needed
+    val imageBitmap =
+        ImageBitmap(width = 100, height = 100) // Replace with a real ImageBitmap if needed
     val histogram = imageBitmap.asAndroidBitmap().colorHistogram()
     BitmapToStitches(
         reducedImageBitmap = imageBitmap,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,15 +7,16 @@ coreKtx = "1.17.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.7.0"
-lifecycleRuntimeKtx = "2.9.2"
+lifecycleRuntimeCompose = "2.9.3"
+lifecycleRuntimeKtx = "2.9.3"
 activityCompose = "1.10.1"
-composeBom = "2025.06.01"
+composeBom = "2025.08.01"
 python = "16.1.0"
 robolectric = "4.15"
 corex = "1.7.0"
 junitKtx = "1.3.0"
 appcompat = "1.7.1"
-material = "1.12.0"
+material = "1.13.0"
 
 [libraries]
 kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlinpoet" }
@@ -26,7 +27,9 @@ test-robolectric = { group = "org.robolectric", name = "robolectric", version.re
 test-core = { group = "androidx.test", name = "core", version.ref = "corex" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeCompose" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
Refactors the detail view to utilize a WizardViewModel for managing state, improving separation of concerns and testability.

Key changes:

Introduces WizardViewModel to handle UI state, including bitmap processing, color reduction, and embroidery creation.
Updates PatchableDetail composable to use WizardViewModel and collect state using collectAsStateWithLifecycle.
Moves bitmap reduction and embroidery creation logic into the ViewModel.
Adds reset functionality to WizardViewModel to clear the state when a different patchable is selected.
Introduces PatchablePreviewMode enum to handle preview modes.