### PR TITLE
Add border to ADT logo

### DIFF
--- a/app/src/main/java/de/berlindroid/zepatch/patchable/AndroidDeveloperTips.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/patchable/AndroidDeveloperTips.kt
@@ -1,7 +1,11 @@
 package de.berlindroid.zepatch.patchable
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -90,12 +94,20 @@ fun AndroidDeveloperTipsLogo(
         shouldCapture = shouldCapture,
         onBitmap = onBitmap,
     ) {
-        Image(
-            modifier = Modifier.size(300.dp),
-            painter = painterResource(R.drawable.adt_logo),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(Color.Green)
-        )
+        Box(
+            Modifier
+                .border(2.dp, Color.Black)
+                .size(300.dp)
+        ) {
+            Image(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                painter = painterResource(R.drawable.adt_logo),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(Color.Green)
+            )
+        }
     }
 }
 


### PR DESCRIPTION
The absence of a border was causing issues for the swing machine. This PR adds a border.

| Before | After |
| - | - |
| <img width="275" height="274" alt="image" src="https://github.com/user-attachments/assets/4c293d48-7ab2-4b17-9f2d-c109f87eb2d1" /> | <img width="276" height="274" alt="Screenshot 2025-09-25 at 23 45 30" src="https://github.com/user-attachments/assets/1154dc60-cc5b-4d39-ab1a-be4d33747cdc" /> |

