### PR TITLE
Better satin borders with OpenCV

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation(project(":patch-annotations"))
     implementation(project(":patch-processor"))
     ksp(project(":patch-processor"))
+    implementation(libs.opencv.android)
     implementation(project(":converter"))
 
     testImplementation(libs.junit)

--- a/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
@@ -28,12 +28,19 @@ import de.berlindroid.zepatch.ui.PatchableDetail
 import de.berlindroid.zepatch.ui.PatchableList
 import de.berlindroid.zepatch.ui.theme.ZePatchTheme
 import kotlinx.coroutines.launch
+import org.opencv.android.OpenCVLoader
+import android.util.Log
 
 @ExperimentalMaterial3Api
 @ExperimentalMaterial3AdaptiveApi
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (!OpenCVLoader.initDebug()) {
+            Log.e("OpenCV", "Unable to load OpenCV!")
+        }
+
         enableEdgeToEdge()
         setContent {
             ZePatchTheme {

--- a/app/src/main/java/de/berlindroid/zepatch/WizardViewModel.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/WizardViewModel.kt
@@ -128,6 +128,7 @@ class WizardViewModel(application: Application) : AndroidViewModel(application) 
             val densityY: Float = 0.4f,
             val borderThickness: Float = 2f,
             val borderDensity: Float = 0.5f,
+            val borderDilation: Int = 5,
 
             // satin border yes no
             // sizes
@@ -254,7 +255,8 @@ class WizardViewModel(application: Application) : AndroidViewModel(application) 
         densityY: Float,
         size: Float,
         borderThickness: Float,
-        borderDensity: Float
+        borderDensity: Float,
+        borderDilationRadius: Int,
     ) {
         _uiState.update {
             when (it) {
@@ -264,6 +266,7 @@ class WizardViewModel(application: Application) : AndroidViewModel(application) 
                     size = size,
                     borderThickness = borderThickness,
                     borderDensity = borderDensity,
+                    borderDilation = borderDilationRadius,
                 )
 
                 else -> it.copyWithError("Cannot update embroidery in state ${it.javaClass.simpleName}.")
@@ -354,6 +357,7 @@ class WizardViewModel(application: Application) : AndroidViewModel(application) 
                     mmDensityY = state.densityY,
                     satinBorderThickness = state.borderThickness,
                     satinBorderDensity = state.borderDensity,
+                    satinBorderDilationRadius = state.borderDilation,
                 )
 
                 val context = getApplication<Application>().applicationContext

--- a/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/BitmapToStitches.kt
@@ -46,6 +46,7 @@ private const val MAX_BORDER = 150f
 
 private const val MIN_SIZE = 10
 private const val MAX_SIZE = 120
+private const val MIN_DILATION = 1
 
 @Composable
 fun BitmapToStitches(
@@ -57,6 +58,7 @@ fun BitmapToStitches(
         size: Float,
         borderThickness: Float,
         borderDensity: Float,
+        borderDilationRadius: Int,
     ) -> Unit,
     onCreateEmbroidery: () -> Unit,
 ) {
@@ -122,7 +124,8 @@ private fun ColumnScope.SuperSecretePirateControls(
         densityY: Float,
         size: Float,
         borderThickness: Float,
-        borderDensity: Float
+        borderDensity: Float,
+        borderDilationRadius: Int,
     ) -> Unit
 ) {
     Card(
@@ -161,6 +164,7 @@ private fun ColumnScope.SuperSecretePirateControls(
                         state.size,
                         state.borderThickness,
                         state.borderDensity,
+                        state.borderDilation,
                     )
                 },
                 onDone = {}
@@ -182,6 +186,7 @@ private fun ColumnScope.SuperSecretePirateControls(
                         state.size,
                         state.borderThickness,
                         state.borderDensity,
+                        state.borderDilation,
                     )
                 },
                 onDone = {}
@@ -203,6 +208,7 @@ private fun ColumnScope.SuperSecretePirateControls(
                         it.toFloat(),
                         state.borderThickness,
                         state.borderDensity,
+                        state.borderDilation,
                     )
                 },
                 onDone = {}
@@ -224,6 +230,7 @@ private fun ColumnScope.SuperSecretePirateControls(
                         state.size,
                         it,
                         state.borderDensity,
+                        state.borderDilation,
                     )
                 },
                 onDone = {}
@@ -245,6 +252,29 @@ private fun ColumnScope.SuperSecretePirateControls(
                         state.size,
                         state.borderThickness,
                         it,
+                        state.borderDilation,
+                    )
+                },
+                onDone = {}
+            )
+
+            IntSelector(
+                modifier = Modifier.fillMaxWidth(),
+                value = "${state.borderDilation}",
+                unit = "mm",
+                label = "satin border gap bridging radius",
+                errorText = { "Radius of $it not in $MIN_DILATION, $MAX_SIZE." },
+                acceptableNumberEntered = {
+                    (it.toIntOrNull() ?: MIN_DILATION) in (MIN_DILATION..MAX_SIZE)
+                },
+                onNumberChanged = {
+                    onUpdateEmbroidery(
+                        state.densityX,
+                        state.densityY,
+                        state.size,
+                        state.borderThickness,
+                        state.borderDensity,
+                        it,
                     )
                 },
                 onDone = {}
@@ -265,7 +295,7 @@ private fun Pirates() {
                 reducedBitmap = randomBitmap(100, 100).asImageBitmap(),
                 reducedHistogram = Histogram(emptyMap())
             ),
-            onUpdateEmbroidery = { _, _, _, _, _ -> }
+            onUpdateEmbroidery = { _, _, _, _, _, _ -> }
         )
     }
 }
@@ -284,7 +314,7 @@ private fun BitmapToStitchesPreview() {
             name = "MyPatch",
             currentlyEmbroidering = false,
         ),
-        onUpdateEmbroidery = { _, _, _, _, _ -> },
+        onUpdateEmbroidery = { _, _, _, _, _, _ -> },
         onCreateEmbroidery = {},
     )
 }

--- a/app/src/main/java/de/berlindroid/zepatch/ui/WizardContent.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/WizardContent.kt
@@ -34,6 +34,7 @@ fun WizardContent(
         size: Float,
         borderThickness: Float,
         borderDensity: Float,
+        borderDilationRadius: Int,
     ) -> Unit,
     onCreateEmbroidery: () -> Unit,
 ) {
@@ -93,7 +94,7 @@ private fun WizardContentPreview() {
         onBitmapUpdated = {},
         onColorCountUpdated = {},
         onComputeReducedBitmap = {},
-        onUpdateEmbroidery = { _, _, _, _, _ -> },
+        onUpdateEmbroidery = { _, _, _, _, _, _ -> },
         onCreateEmbroidery = {},
     )
 }

--- a/converter/build.gradle.kts
+++ b/converter/build.gradle.kts
@@ -50,4 +50,5 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.jts)
+    implementation(libs.opencv.android)
 }

--- a/converter/src/main/java/de/berlindroid/zepatch/stiches/StitchToPES.kt
+++ b/converter/src/main/java/de/berlindroid/zepatch/stiches/StitchToPES.kt
@@ -102,6 +102,7 @@ object StitchToPES {
         mmDensityY: Float,
         satinBorderThickness: Float,
         satinBorderDensity: Float,
+        satinBorderDilationRadius: Int,
     ): Embroidery {
         val strandsPerColor =
             bitmap.getColorStrands(
@@ -128,7 +129,7 @@ object StitchToPES {
                 distance = satinBorderDensity,
                 widthMm = mmWidth * 10,
                 heightMm = mmHeight * 10,
-                dilationRadius = 5,
+                dilationRadius = satinBorderDilationRadius,
             )
         } else {
             listOf()

--- a/converter/src/main/java/de/berlindroid/zepatch/stiches/StitchToPES.kt
+++ b/converter/src/main/java/de/berlindroid/zepatch/stiches/StitchToPES.kt
@@ -14,7 +14,11 @@ import com.embroidermodder.punching.colors
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryFactory
-import kotlin.collections.toMutableMap
+import org.opencv.android.Utils
+import org.opencv.core.Mat
+import org.opencv.core.MatOfPoint
+import org.opencv.core.Size
+import org.opencv.imgproc.Imgproc
 import kotlin.io.encoding.Base64
 import kotlin.math.floor
 import kotlin.math.sqrt
@@ -118,10 +122,13 @@ object StitchToPES {
         }.toTypedArray()
 
         val border = if (satinBorderThickness > 0.1f && satinBorderDensity > 0.05f) {
-            threads.satinBorder(
+            bitmap.satinBorder(
                 color = Color.BLACK,
                 thickness = satinBorderThickness,
                 distance = satinBorderDensity,
+                widthMm = mmWidth * 10,
+                heightMm = mmHeight * 10,
+                dilationRadius = 5,
             )
         } else {
             listOf()
@@ -132,34 +139,68 @@ object StitchToPES {
         )
     }
 
-    private fun Array<Thread>.satinBorder(
+    private fun Bitmap.satinBorder(
         color: Int,
         thickness: Float,
-        distance: Float
+        distance: Float,
+        widthMm: Float,
+        heightMm: Float,
+        dilationRadius: Int,
     ): List<Thread> {
-        val factory = GeometryFactory()
-        val points = factory.createMultiPointFromCoords(
-            stitches.map { Coordinate(it.x.toDouble(), it.y.toDouble()) }.toTypedArray()
+        val mat = Mat()
+        val contours = mutableListOf<MatOfPoint>()
+
+        val scaleX = (widthMm / width).toDouble()
+        val scaleY = (heightMm / height).toDouble()
+        // Convert Bitmap to Mat and resize.
+        Utils.bitmapToMat(this, mat)
+        Imgproc.resize(
+            mat,
+            mat,
+            Size(0.0, 0.0),
+            scaleX,
+            scaleY,
+            Imgproc.INTER_NEAREST,
+        )
+        // Convert to grayscale and apply binary threshold,
+        // as for finding contours the image should be a white object on a black background.
+        Imgproc.cvtColor(mat, mat, Imgproc.COLOR_BGR2GRAY)
+        val thresh = Mat()
+        Imgproc.threshold(mat, thresh, 0.0, 255.0, Imgproc.THRESH_BINARY)
+
+        // MARK: morphological filters
+        val kernelDimension = (dilationRadius * 2 + 1).toDouble()
+        val kernelSize = Size(kernelDimension, kernelDimension)
+        val kernel = Imgproc.getStructuringElement(Imgproc.MORPH_ELLIPSE, kernelSize)
+
+        // Dilation to close small gaps.
+        Imgproc.dilate(thresh, thresh, kernel)
+        // Erosion shrinks back to original border positions and helps remove small noise.
+        Imgproc.erode(thresh, thresh, kernel)
+        // MARK: End morphological filters
+
+        val hierarchy = Mat() // Not used.
+        Imgproc.findContours(
+            thresh,
+            contours,
+            hierarchy,
+            Imgproc.RETR_EXTERNAL,  // Only outer contours
+            Imgproc.CHAIN_APPROX_TC89_L1 // Reduced details in output
         )
 
-        val hull = points.convexHull()
-        val outer = hull.buffer(thickness / 2.0)
-
-        return listOf(
-//            Thread(
-//                color = Color.WHITE,
-//                stitches = outer.toStitch(),
-//                absolute = true,
-//            ),
+        val outer = contours.asGeometries()
+        val threads = outer.map {
             Thread(
                 color = color,
-                stitches = outer.toZigZagStitch(
+                stitches = it.toZigZagStitch(
                     thickness * 10,
                     distance * 10
                 ),
                 absolute = true,
             )
-        )
+        }
+
+        return threads
     }
 }
 
@@ -316,6 +357,20 @@ private fun List<XY>.removeDoubles() = filterIndexed { index, xy ->
     }
 }
 
+private fun List<MatOfPoint>.asGeometries(): List<Geometry> {
+    val geometryFactory = GeometryFactory()
+    val polygons = this.mapNotNull { contour ->
+        val points = contour.toArray().map { Coordinate(it.x, it.y) }.toTypedArray()
+
+        if (points.size < 3) return@mapNotNull null
+
+        val closed = if (points.first() != points.last()) points + points.first() else points
+        val ring = geometryFactory.createLinearRing(closed)
+        geometryFactory.createPolygon(ring)
+    }
+
+    return polygons.toMutableList()
+}
 
 private val Float.floor: Int
     get() = floor(this).toInt()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lifecycleRuntimeCompose = "2.9.3"
 lifecycleRuntimeKtx = "2.9.3"
 activityCompose = "1.10.1"
 composeBom = "2025.08.01"
+opencvAndroid = "4.5.3.0"
 python = "16.1.0"
 robolectric = "4.15"
 corex = "1.7.0"
@@ -24,6 +25,7 @@ coil = "3.3.0"
 
 [libraries]
 kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlinpoet" }
+opencv-android = { group = "com.quickbirdstudios", name = "opencv", version.ref = "opencvAndroid" }
 symbol-processing-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
Replaced satin borders convex hull method with OpenCV's contour finder.

Features:
- Accurate borders wrapping the shape of the patch
- Adjustable small gap bridging and path smoothing using dilate/erode filters
- Support for individual borders in disjoint shapes

Examples:

<p> 
<img width=250 src=https://github.com/user-attachments/assets/f0a0777f-62fe-49d1-bb80-dcf74daca693/>
<img width=250 src=https://github.com/user-attachments/assets/5ef9396c-0fa5-40e3-88ef-232fea009415/>
<img width=250 src=https://github.com/user-attachments/assets/3f05e325-9f00-4758-bcbd-20debf4fa82c/>
<img width=250 src=https://github.com/user-attachments/assets/6a812a51-419f-433e-b3c4-60bbc959bdab/>
<img width=250 src=https://github.com/user-attachments/assets/0cae0c7e-530a-4989-8a8f-31905baea6e0/>
<img width=250 src=https://github.com/user-attachments/assets/873727a8-eaa4-445e-96d1-800991a6ff53/>
</p>